### PR TITLE
rewriting imports to use github

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ package main
 import (
 	"fmt"
 
-	"pault.ag/go/topsort"
+	"github.com/paultag/go-topsort"
 )
 
 func main() {

--- a/topsort_test.go
+++ b/topsort_test.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"testing"
 
-	"pault.ag/go/topsort"
+	"github.com/paultag/go-topsort"
 )
 
 // Test Helpers {{{


### PR DESCRIPTION
Currently https://pault.ag/go/debian is down which breaks the import of this package. At my place of employment we use dep to manage dependencies and while dep supports using a different source url, it does a name validation and the original domain name must be reachable.

golang/dep#1159

This change will remove the custom domain as a potential point of failure in the import process and allow the package to be imported directly from github.